### PR TITLE
fix: replace then with async await in tests

### DIFF
--- a/client/client.test.js
+++ b/client/client.test.js
@@ -5,7 +5,6 @@ describe('basic', () => {
   it('pings', async () => {
     const response = await axios.get('/ping')
     expect(response).toEqual('pong')
-    })
   })
 })
 


### PR DESCRIPTION
## Description

Replace then with async await in tests, resolves https://github.com/artsy/klimt/issues/17
